### PR TITLE
Feat/add db in memory option 20240412

### DIFF
--- a/gffquant/__init__.py
+++ b/gffquant/__init__.py
@@ -5,7 +5,7 @@
 from enum import Enum, auto, unique
 
 
-__version__ = "2.15.1"
+__version__ = "2.16.0"
 __tool__ = "gffquant"
 
 

--- a/gffquant/__main__.py
+++ b/gffquant/__main__.py
@@ -92,6 +92,8 @@ def main():
                 db_input, db_args["input_data2"] = args.annotation_db.split(",")
             except ValueError as exc:
                 raise ValueError("Require two input files.") from exc
+        else:
+            kwargs["in_memory"] = args.db_in_memory
 
         annotation_db.build_database(
             db_input,
@@ -130,6 +132,7 @@ def main():
         report_unannotated=args.run_mode.report_unannotated,
         dump_counters=args.debug,
         restrict_reports=args.restrict_metrics,
+        in_memory=args.db_in_memory,
     )
 
 

--- a/gffquant/db/annotation_db.py
+++ b/gffquant/db/annotation_db.py
@@ -22,9 +22,9 @@ class AnnotationDatabaseManager(ABC):
         ...
 
     @classmethod
-    def from_db(cls, db_path):
+    def from_db(cls, db_path, in_memory=True):
         if isinstance(db_path, str):
-            return SQL_ADM(get_database(db_path)[1])
+            return SQL_ADM(get_database(db_path, in_memory=in_memory)[1])
         if isinstance(db_path, GqDatabaseImporter):
             return Dict_ADM(db_path)
         return SQL_ADM(db_path)

--- a/gffquant/handle_args.py
+++ b/gffquant/handle_args.py
@@ -113,6 +113,12 @@ def handle_args(args):
         help="Format of the annotation database.",
     )
 
+    ap.add_argument(
+        "--db_in_memory",
+        action="store_true",
+        help="Load the database into memory (only for sqlite-based databases.)",
+    )
+
     # ap.add_argument(
     #     "--db_coordinates",
     #     type=str,

--- a/gffquant/profilers/feature_quantifier.py
+++ b/gffquant/profilers/feature_quantifier.py
@@ -136,9 +136,10 @@ class FeatureQuantifier(ABC):
         report_category=True,
         report_unannotated=True,
         dump_counters=True,
+        in_memory=True,
     ):
         if self.adm is None:
-            self.adm = AnnotationDatabaseManager.from_db(self.db)
+            self.adm = AnnotationDatabaseManager.from_db(self.db, in_memory=in_memory)
 
         if dump_counters:
             self.count_manager.dump_raw_counters(self.out_prefix, self.reference_manager)
@@ -294,6 +295,7 @@ class FeatureQuantifier(ABC):
         report_category=False,
         report_unannotated=False,
         dump_counters=False,
+        in_memory=True,
     ):
 
         with gzip.open(f"{self.out_prefix}.aln_stats.txt.gz", "wt") as aln_stats_out:
@@ -315,6 +317,7 @@ class FeatureQuantifier(ABC):
                 report_category=report_category,
                 report_unannotated=report_unannotated,
                 dump_counters=dump_counters,
+                in_memory=in_memory,
             )
 
             for metric, value in (

--- a/gffquant/profilers/region_quantifier.py
+++ b/gffquant/profilers/region_quantifier.py
@@ -22,6 +22,7 @@ class RegionQuantifier(FeatureQuantifier):
         strand_specific=False,
         paired_end_count=1,
         run_mode=RunMode.DOMAIN,
+        in_memory=True,
     ):
         FeatureQuantifier.__init__(
             self,
@@ -33,4 +34,4 @@ class RegionQuantifier(FeatureQuantifier):
             paired_end_count=paired_end_count,
         )
 
-        self.adm = AnnotationDatabaseManager.from_db(self.db)
+        self.adm = AnnotationDatabaseManager.from_db(self.db, in_memory=in_memory)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added a command-line argument `--db_in_memory` to allow loading the database into memory, enhancing performance for sqlite-based databases.

- **Enhancements**
	- Improved memory management across various modules by incorporating the `in_memory` parameter to control database loading behavior.

- **Bug Fixes**
	- Ensured consistent handling of the `in_memory` parameter across different functions and methods for better stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->