### PR TITLE
Fix/samfile output 20240513

### DIFF
--- a/gffquant/__init__.py
+++ b/gffquant/__init__.py
@@ -5,7 +5,7 @@
 from enum import Enum, auto, unique
 
 
-__version__ = "2.16.2"
+__version__ = "2.16.3"
 __tool__ = "gffquant"
 
 

--- a/gffquant/__main__.py
+++ b/gffquant/__main__.py
@@ -41,7 +41,7 @@ def stream_alignments(args, profiler):
         debug_samfile, samfile = None, None
         if args.keep_alignment_file:
             samfile = args.keep_alignment_file.replace(".sam", "")
-            samfile = f"{samfile}.{sam_suffix}.sam"
+            samfile = f"{samfile}{sam_suffix}.sam"
         if profiler.debug:
             debug_samfile = f"{profiler.out_prefix}{sam_suffix}.filtered.sam"
 

--- a/gffquant/__main__.py
+++ b/gffquant/__main__.py
@@ -35,7 +35,17 @@ def stream_alignments(args, profiler):
     for i, (input_type, *reads) in enumerate(args.input_data):
 
         logger.info("Running %s alignment: %s", input_type, ",".join(reads))
-        proc, call = aln_runner.run(reads, single_end_reads=input_type == "single", alignment_file=args.keep_alignment_file)
+
+        sam_suffix=f".{input_type}.{i}"
+
+        debug_samfile, samfile = None, None
+        if args.keep_alignment_file:
+            samfile = args.keep_alignment_file.replace(".sam", "")
+            samfile = f"{samfile}.{sam_suffix}.sam"
+        if profiler.debug:
+            debug_samfile = f"{profiler.out_prefix}{sam_suffix}.filtered.sam"
+
+        proc, call = aln_runner.run(reads, single_end_reads=input_type == "single", alignment_file=samfile)
 
         # if proc.returncode != 0:
         #     logger.error("Encountered problems aligning.")
@@ -49,7 +59,7 @@ def stream_alignments(args, profiler):
 
             profiler.count_alignments(
                 proc.stdout, aln_format="sam", min_identity=args.min_identity, min_seqlen=args.min_seqlen,
-                sam_prefix=f".{input_type}.{i}",
+                debug_samfile=debug_samfile,
             )
 
         except Exception as err:

--- a/gffquant/profilers/feature_quantifier.py
+++ b/gffquant/profilers/feature_quantifier.py
@@ -190,17 +190,15 @@ class FeatureQuantifier(ABC):
 
         return new_ref[0]
 
-    def process_alignments(self, aln_reader, sam_prefix="", min_identity=None, min_seqlen=None, unmarked_orphans=False):
+    def process_alignments(self, aln_reader, debug_samfile=None, min_identity=None, min_seqlen=None, unmarked_orphans=False):
         # pylint: disable=R0914
         t0 = time.time()
-
-        samfile = f"{self.out_prefix}{sam_prefix}.filtered.sam" if self.debug else None
 
         aln_stream = aln_reader.get_alignments(
             min_identity=min_identity,
             min_seqlen=min_seqlen,
             filter_flags=SamFlags.SUPPLEMENTARY_ALIGNMENT,
-            filtered_sam=samfile,
+            filtered_sam=debug_samfile,
         )
 
         self.count_manager.toggle_single_read_handling(unmarked_orphans)
@@ -265,7 +263,7 @@ class FeatureQuantifier(ABC):
         min_seqlen=None,
         external_readcounts=None,
         unmarked_orphans=False,
-        sam_prefix="",
+        debug_samfile=None,
     ):
         aln_reader = AlignmentProcessor(aln_stream, aln_format)
 
@@ -274,7 +272,7 @@ class FeatureQuantifier(ABC):
             min_identity=min_identity,
             min_seqlen=min_seqlen,
             unmarked_orphans=unmarked_orphans,
-            sam_prefix=sam_prefix,
+            debug_samfile=debug_samfile,
         )
 
         full_readcount, read_count, filtered_readcount = aln_reader.read_counter


### PR DESCRIPTION
* version 2.16.3
* `--keep_alignment_file` with multiple input fastq sets no longer concatenates the alignments into a single bam